### PR TITLE
Add memory-aware training presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,14 +193,15 @@ python benchmarks/benchmark_generation_mamba_simple.py --model-name "state-space
 
 ## Training
 
-`mamba_ssm/training/train_mambagpt.py` provides a minimal training loop for MambaGPT that fits on 12GB GPUs.
-It streams a text corpus from disk, supports gradient checkpointing and runs with PyTorch AMP.
+`mamba_ssm/training/train_mambagpt.py` provides a minimal training loop for MambaGPT.
+It now contains hardware-aware presets and automatically tunes batch size and context length based on available VRAM.
+The script still streams a text corpus from disk, supports gradient checkpointing and runs with PyTorch AMP.
 
 Example:
 
 ``` sh
 python -m mamba_ssm.training.train_mambagpt \
-  --train-file path/to/text.txt --batch-size 4 --seq-len 128 \
+  --train-file path/to/text.txt --auto-config --batch-size 0 \
   --epochs 1 --fp16 --checkpointing
 ```
 

--- a/mamba_ssm/training/autoconfig.py
+++ b/mamba_ssm/training/autoconfig.py
@@ -1,0 +1,54 @@
+import torch
+from dataclasses import dataclass
+from typing import Dict
+
+PRESET_CONFIGS: Dict[str, Dict[str, int]] = {
+    "tiny": {"d_model": 256, "n_layer": 8},
+    "small": {"d_model": 512, "n_layer": 12},
+    "base": {"d_model": 768, "n_layer": 12},
+}
+
+def detect_total_vram_gb(device=None) -> float:
+    if not torch.cuda.is_available():
+        return 0.0
+    if device is None:
+        device = torch.cuda.current_device()
+    prop = torch.cuda.get_device_properties(device)
+    return prop.total_memory / 1024 ** 3
+
+def detect_free_vram_gb(device=None) -> float:
+    if not torch.cuda.is_available():
+        return 0.0
+    if device is None:
+        device = torch.cuda.current_device()
+    free, _ = torch.cuda.mem_get_info(device)
+    return free / 1024 ** 3
+
+def select_preset_by_vram(total_vram_gb: float) -> str:
+    if total_vram_gb < 10:
+        return "tiny"
+    elif total_vram_gb < 20:
+        return "small"
+    else:
+        return "base"
+
+def autotune_batch_size(free_mem_gb: float) -> int:
+    if free_mem_gb < 4:
+        return 1
+    elif free_mem_gb < 8:
+        return 2
+    elif free_mem_gb < 16:
+        return 4
+    else:
+        return 8
+
+@dataclass
+class ContextLenWarmup:
+    start: int = 512
+    target: int = 2048
+    steps: int = 1000
+
+    def get(self, step: int) -> int:
+        if step >= self.steps:
+            return self.target
+        return int(self.start + (self.target - self.start) * step / self.steps)

--- a/mamba_ssm/training/train_mambagpt.py
+++ b/mamba_ssm/training/train_mambagpt.py
@@ -11,6 +11,14 @@ from transformers import AutoTokenizer
 from bitsandbytes.optim import Adam8bit
 
 from mamba_ssm.models.mamba_gpt import MambaGPT, MambaGPTConfig
+from mamba_ssm.training.autoconfig import (
+    PRESET_CONFIGS,
+    ContextLenWarmup,
+    autotune_batch_size,
+    detect_free_vram_gb,
+    detect_total_vram_gb,
+    select_preset_by_vram,
+)
 
 
 class StreamingTextDataset(IterableDataset):
@@ -43,13 +51,16 @@ def monitor_vram(threshold_gb: float = 11.0):
 def main():
     parser = argparse.ArgumentParser(description="Train MambaGPT with low VRAM usage")
     parser.add_argument("--train-file", type=str, required=True)
-    parser.add_argument("--batch-size", type=int, default=4)
-    parser.add_argument("--seq-len", type=int, default=128)
+    parser.add_argument("--batch-size", type=int, default=0, help="0 to auto tune")
+    parser.add_argument("--seq-len", type=int, default=2048)
     parser.add_argument("--epochs", type=int, default=1)
     parser.add_argument("--lr", type=float, default=2e-4)
     parser.add_argument("--fp16", action="store_true")
     parser.add_argument("--bf16", action="store_true")
     parser.add_argument("--checkpointing", action="store_true")
+    parser.add_argument("--preset", type=str, choices=list(PRESET_CONFIGS.keys()))
+    parser.add_argument("--auto-config", action="store_true", help="select preset based on VRAM")
+    parser.add_argument("--warmup-steps", type=int, default=1000)
     args = parser.parse_args()
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -60,30 +71,58 @@ def main():
         amp_dtype = torch.float16
 
     tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b")
-    ds = StreamingTextDataset(args.train_file, tokenizer, seq_len=args.seq_len)
-    loader = DataLoader(ds, batch_size=args.batch_size)
 
-    config = MambaGPTConfig()
+    total_vram = detect_total_vram_gb()
+    if args.auto_config and args.preset is None:
+        args.preset = select_preset_by_vram(total_vram)
+    cfg_kwargs = PRESET_CONFIGS.get(args.preset or "base", {})
+    config = MambaGPTConfig(**cfg_kwargs)
     model = MambaGPT(config, device=device, gradient_checkpointing=args.checkpointing)
     model.to(device)
 
+    free_vram = detect_free_vram_gb()
+    if args.batch_size == 0:
+        args.batch_size = autotune_batch_size(free_vram)
+
+    warmup = ContextLenWarmup(target=args.seq_len, steps=args.warmup_steps)
+    ds = StreamingTextDataset(args.train_file, tokenizer, seq_len=warmup.start)
+    loader = DataLoader(ds, batch_size=args.batch_size)
+
+    
     optimizer = Adam8bit(model.parameters(), lr=args.lr)
     scaler = GradScaler(enabled=amp_dtype != torch.float32)
 
     model.train()
+    step = 0
     for _ in range(args.epochs):
         for input_ids, targets in loader:
+            ds.seq_len = warmup.get(step)
             input_ids = input_ids.to(device)
             targets = targets.to(device)
-            with autocast(device_type="cuda", dtype=amp_dtype) if device == "cuda" else nullcontext():
-                logits = model(input_ids)
-                loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1))
-            scaler.scale(loss).backward()
-            scaler.step(optimizer)
-            scaler.update()
-            optimizer.zero_grad(set_to_none=True)
-            monitor_vram()
-            print(f"loss: {loss.item():.4f}")
+            try:
+                with autocast(device_type="cuda", dtype=amp_dtype) if device == "cuda" else nullcontext():
+                    logits = model(input_ids)
+                    loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1))
+                scaler.scale(loss).backward()
+                scaler.step(optimizer)
+                scaler.update()
+                optimizer.zero_grad(set_to_none=True)
+                monitor_vram()
+                print(f"loss: {loss.item():.4f}")
+            except RuntimeError as e:
+                if "out of memory" in str(e).lower():
+                    torch.cuda.empty_cache()
+                    if args.batch_size > 1:
+                        args.batch_size = max(1, args.batch_size // 2)
+                        loader = DataLoader(ds, batch_size=args.batch_size)
+                        print(f"[WARN] OOM encountered. Reducing batch size to {args.batch_size}")
+                        continue
+                    else:
+                        print("[ERROR] OOM with batch size 1. Skipping batch.")
+                        continue
+                else:
+                    raise
+            step += 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- provide automatic hardware-aware configuration in `autoconfig`
- update training script with preset selection, batch size autotuner, context length warmup and OOM fallback
- document new workflow in README

## Testing
- `pytest -q tests/test_generation.py::test_generation` *(fails: ModuleNotFoundError: No module named 'mamba_ssm')*


------
https://chatgpt.com/codex/tasks/task_e_68407f98cb74832da5b268d14166c7ce