### PR TITLE
Add padding_idx to embeddings

### DIFF
--- a/mamba_ssm/models/mamba_gpt.py
+++ b/mamba_ssm/models/mamba_gpt.py
@@ -52,7 +52,9 @@ class MambaGPT(nn.Module):
         factory_kwargs = {"device": device, "dtype": dtype}
         self.config = config
 
-        self.embed_tokens = nn.Embedding(config.vocab_size, config.d_model, **factory_kwargs)
+        self.embed_tokens = nn.Embedding(
+            config.vocab_size, config.d_model, padding_idx=0, **factory_kwargs
+        )
         self.blocks = nn.ModuleList(
             [MambaBlock(config.d_model, i, config.mamba_kwargs, device=device, dtype=dtype) for i in range(config.n_layer)]
         )

--- a/mamba_ssm/models/mixer_seq_simple.py
+++ b/mamba_ssm/models/mixer_seq_simple.py
@@ -137,7 +137,9 @@ class MixerModel(nn.Module):
         super().__init__()
         self.residual_in_fp32 = residual_in_fp32
 
-        self.embedding = nn.Embedding(vocab_size, d_model, **factory_kwargs)
+        self.embedding = nn.Embedding(
+            vocab_size, d_model, padding_idx=0, **factory_kwargs
+        )
 
         # We change the order of residual and layer norm:
         # Instead of LN -> Attn / MLP -> Add, we do:


### PR DESCRIPTION
## Summary
- set `padding_idx=0` when building token embeddings in `MambaGPT` and in `MixerModel`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mamba_ssm')*

------
https://chatgpt.com/codex/tasks/task_e_68408c453e28832da6356dc2705ddc6f