### PR TITLE
Add seq len fallback on OOM

### DIFF
--- a/mamba_ssm/training/train_mambagpt.py
+++ b/mamba_ssm/training/train_mambagpt.py
@@ -118,8 +118,16 @@ def main():
                         print(f"[WARN] OOM encountered. Reducing batch size to {args.batch_size}")
                         continue
                     else:
-                        print("[ERROR] OOM with batch size 1. Skipping batch.")
-                        continue
+                        if ds.seq_len > 512:
+                            ds.seq_len = 512
+                            warmup.start = min(warmup.start, 512)
+                            warmup.target = 512
+                            loader = DataLoader(ds, batch_size=args.batch_size)
+                            print("[WARN] OOM with batch size 1. Reducing sequence length to 512")
+                            continue
+                        else:
+                            print("[ERROR] OOM with batch size 1. Skipping batch.")
+                            continue
                 else:
                     raise
             step += 1


### PR DESCRIPTION
## Summary
- shrink sequence length to 512 if OOM occurs with batch size 1
- reinitialize dataloader and warn when fallback triggers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mamba_ssm')*


------
https://chatgpt.com/codex/tasks/task_e_68408c698698832dad17083a22fb9721