### PR TITLE
Improve VRAM-aware batch size autotuning

### DIFF
--- a/mamba_ssm/training/train_mambagpt.py
+++ b/mamba_ssm/training/train_mambagpt.py
@@ -15,7 +15,6 @@ from mamba_ssm.training.autoconfig import (
     PRESET_CONFIGS,
     ContextLenWarmup,
     autotune_batch_size,
-    detect_free_vram_gb,
     detect_total_vram_gb,
     select_preset_by_vram,
 )
@@ -80,9 +79,8 @@ def main():
     model = MambaGPT(config, device=device, gradient_checkpointing=args.checkpointing)
     model.to(device)
 
-    free_vram = detect_free_vram_gb()
     if args.batch_size == 0:
-        args.batch_size = autotune_batch_size(free_vram)
+        args.batch_size = autotune_batch_size()
 
     warmup = ContextLenWarmup(target=args.seq_len, steps=args.warmup_steps)
     ds = StreamingTextDataset(args.train_file, tokenizer, seq_len=warmup.start)


### PR DESCRIPTION
## Summary
- update `autotune_batch_size` to use a loop that checks free VRAM
- add `est_batch_vram` helper for rough per-batch VRAM estimate
- adjust training script to call new function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mamba_ssm')*

------
https://chatgpt.com/codex/tasks/task_e_68408c614244832d941865247066a00e