### PR TITLE
Update preset model sizes

### DIFF
--- a/mamba_ssm/training/autoconfig.py
+++ b/mamba_ssm/training/autoconfig.py
@@ -3,9 +3,9 @@ from dataclasses import dataclass
 from typing import Dict
 
 PRESET_CONFIGS: Dict[str, Dict[str, int]] = {
-    "tiny": {"d_model": 256, "n_layer": 8},
-    "small": {"d_model": 512, "n_layer": 12},
-    "base": {"d_model": 768, "n_layer": 12},
+    "tiny": {"d_model": 256, "n_layer": 12},
+    "small": {"d_model": 512, "n_layer": 16},
+    "base": {"d_model": 768, "n_layer": 24},
 }
 
 def detect_total_vram_gb(device=None) -> float:


### PR DESCRIPTION
## Summary
- tune preset hyperparameters in `autoconfig`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'einops')*

------
https://chatgpt.com/codex/tasks/task_e_68408c5355b0832d9e56b07208fd9b7c