### PR TITLE
Increase context warmup default steps

### DIFF
--- a/mamba_ssm/training/autoconfig.py
+++ b/mamba_ssm/training/autoconfig.py
@@ -46,7 +46,7 @@ def autotune_batch_size(free_mem_gb: float) -> int:
 class ContextLenWarmup:
     start: int = 512
     target: int = 2048
-    steps: int = 1000
+    steps: int = 10_000
 
     def get(self, step: int) -> int:
         if step >= self.steps:

--- a/mamba_ssm/training/train_mambagpt.py
+++ b/mamba_ssm/training/train_mambagpt.py
@@ -60,7 +60,7 @@ def main():
     parser.add_argument("--checkpointing", action="store_true")
     parser.add_argument("--preset", type=str, choices=list(PRESET_CONFIGS.keys()))
     parser.add_argument("--auto-config", action="store_true", help="select preset based on VRAM")
-    parser.add_argument("--warmup-steps", type=int, default=1000)
+    parser.add_argument("--warmup-steps", type=int, default=10_000)
     args = parser.parse_args()
 
     device = "cuda" if torch.cuda.is_available() else "cpu"


### PR DESCRIPTION
## Summary
- default `ContextLenWarmup.steps` to `10_000`
- match CLI argument default in `train_mambagpt.py`

## Testing
- `pytest -q` *(fails: OSError: libtorch_global_deps.so: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68408c5e9b04832db7112d23bad0bc61