### PR TITLE
[TEST] Add MambaGPT validation suite

### DIFF
--- a/mamba_ssm/utils/param_counter.py
+++ b/mamba_ssm/utils/param_counter.py
@@ -1,0 +1,19 @@
+import argparse
+from mamba_ssm.models.mamba_gpt import MambaGPT, MambaGPTConfig
+from mamba_ssm.training.autoconfig import PRESET_CONFIGS
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=str, default="base")
+    args = parser.parse_args()
+
+    cfg_kwargs = PRESET_CONFIGS.get(args.config, {})
+    config = MambaGPTConfig(**cfg_kwargs)
+    model = MambaGPT(config)
+    num_params = model.num_parameters(only_trainable=True)
+    print(num_params)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_amp_stability.py
+++ b/tests/test_amp_stability.py
@@ -1,0 +1,21 @@
+import torch
+from torch.cuda.amp import autocast, GradScaler
+from mamba_ssm.models.mixer_seq_simple import MambaLMHeadModel
+from mamba_ssm.models.config_mamba import MambaConfig
+
+
+def test_amp_training_step():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    cfg = MambaConfig(d_model=64, n_layer=2, vocab_size=100)
+    model = MambaLMHeadModel(cfg, device=device)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    scaler = GradScaler(enabled=True)
+    inp = torch.randint(0, cfg.vocab_size, (1, 32), device=device)
+    tgt = inp.clone()
+    with autocast(device_type="cuda" if torch.cuda.is_available() else "cpu", dtype=torch.bfloat16):
+        logits = model(inp).logits
+        loss = torch.nn.functional.cross_entropy(logits.view(-1, logits.size(-1)), tgt.view(-1))
+    scaler.scale(loss).backward()
+    scaler.step(opt)
+    scaler.update()
+    assert not torch.isnan(loss).any()

--- a/tests/test_cache_consistency.py
+++ b/tests/test_cache_consistency.py
@@ -1,0 +1,24 @@
+import torch
+from mamba_ssm.models.mixer_seq_simple import MambaLMHeadModel
+from mamba_ssm.models.config_mamba import MambaConfig
+from mamba_ssm.utils.generation import InferenceParams
+
+
+def test_cache_consistency():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    cfg = MambaConfig(d_model=64, n_layer=2, vocab_size=100)
+    model = MambaLMHeadModel(cfg, device=device)
+    prompt = torch.randint(0, cfg.vocab_size, (1, 20), device=device)
+
+    # Run generation without cache
+    logits_full = model(prompt).logits
+
+    # Run autoregressive with cache
+    inference_params = InferenceParams(max_seqlen=20, max_batch_size=1)
+    logits_cached = []
+    for i in range(prompt.shape[1]):
+        inp = prompt[:, i:i+1]
+        logits = model(inp, inference_params=inference_params, num_last_tokens=1).logits
+        logits_cached.append(logits)
+    logits_cached = torch.cat(logits_cached, dim=1)
+    assert torch.allclose(logits_full, logits_cached, atol=1e-4, rtol=1e-4)

--- a/tests/test_generation_latency.py
+++ b/tests/test_generation_latency.py
@@ -1,0 +1,17 @@
+import time
+import torch
+from mamba_ssm.models.mixer_seq_simple import MambaLMHeadModel
+from mamba_ssm.models.config_mamba import MambaConfig
+
+
+def test_generation_latency():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    cfg = MambaConfig(d_model=64, n_layer=2, vocab_size=100)
+    model = MambaLMHeadModel(cfg, device=device)
+    prompt = torch.randint(0, cfg.vocab_size, (1, 10), device=device)
+    latencies = []
+    for length in [50, 100, 200]:
+        start = time.time()
+        model.generate(input_ids=prompt, max_length=length, cg=False)
+        latencies.append(time.time() - start)
+    assert latencies[0] <= latencies[1] <= latencies[2]

--- a/tests/test_long_sequence_memory.py
+++ b/tests/test_long_sequence_memory.py
@@ -1,0 +1,16 @@
+import torch
+from mamba_ssm.models.mixer_seq_simple import MambaLMHeadModel
+from mamba_ssm.models.config_mamba import MambaConfig
+
+
+def test_long_sequence_memory():
+    """Ensure forward pass works for long sequences without OOM."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    cfg = MambaConfig(d_model=64, n_layer=2, vocab_size=100)
+    model = MambaLMHeadModel(cfg, device=device)
+    seq_len = 4096
+    inp = torch.randint(0, cfg.vocab_size, (1, seq_len), device=device)
+    try:
+        _ = model(inp).logits
+    except RuntimeError as e:
+        assert "out of memory" not in str(e).lower()

--- a/tests/test_param_equivalence.py
+++ b/tests/test_param_equivalence.py
@@ -1,0 +1,18 @@
+import torch
+from transformers import GPT2Config, GPT2Model
+from mamba_ssm.models.mixer_seq_simple import MambaLMHeadModel
+from mamba_ssm.models.config_mamba import MambaConfig
+
+
+def test_param_equivalence():
+    """Compare parameter counts with a tiny GPT2 configuration."""
+    cfg_mamba = MambaConfig(d_model=64, n_layer=2, vocab_size=100)
+    mamba = MambaLMHeadModel(cfg_mamba)
+
+    gpt_cfg = GPT2Config(n_embd=64, n_layer=2, n_head=8, vocab_size=100)
+    gpt = GPT2Model(gpt_cfg)
+
+    mamba_params = sum(p.numel() for p in mamba.parameters() if p.requires_grad)
+    gpt_params = sum(p.numel() for p in gpt.parameters() if p.requires_grad)
+    diff = abs(mamba_params - gpt_params) / gpt_params
+    assert diff < 0.2


### PR DESCRIPTION
## VRAM impact analysis
New tests run tiny model configs and do not change runtime memory requirements.

## CPU validation results
Core tests could not execute because PyTorch was unavailable in the environment.

## Affected components diagram
```
tests/
├── test_amp_stability.py
├── test_cache_consistency.py
├── test_generation_latency.py
├── test_long_sequence_memory.py
└── test_param_equivalence.py
mamba_ssm/utils/param_counter.py
```

## Risk assessment for OOM scenarios
The long sequence memory test stresses 4096-token inputs with a small model to avoid exceeding 12GB VRAM. No other changes increase memory usage.

------
https://chatgpt.com/codex/tasks/task_e_6840a400f368832d8ea24ddfe15064a4