### PR TITLE
[TEST] skip when torch unavailable

### DIFF
--- a/tests/ops/test_selective_scan.py
+++ b/tests/ops/test_selective_scan.py
@@ -2,9 +2,10 @@
 
 import math
 
-import torch
-import torch.nn.functional as F
 import pytest
+torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")
+import torch.nn.functional as F
 
 from einops import rearrange
 

--- a/tests/ops/test_selective_scan_cpu.py
+++ b/tests/ops/test_selective_scan_cpu.py
@@ -2,7 +2,9 @@ import sys
 import types
 from unittest import mock
 
-import torch
+import pytest
+torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")
 
 # Provide a dummy selective_scan_cuda so selective_scan_interface imports
 sys.modules.setdefault('selective_scan_cuda', types.ModuleType('selective_scan_cuda'))

--- a/tests/ops/triton/test_layernorm_gated.py
+++ b/tests/ops/triton/test_layernorm_gated.py
@@ -1,9 +1,9 @@
 import math
 
-import torch
-import torch.nn.functional as F
-
 import pytest
+torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")
+import torch.nn.functional as F
 
 from einops import rearrange, repeat
 

--- a/tests/ops/triton/test_selective_state_update.py
+++ b/tests/ops/triton/test_selective_state_update.py
@@ -2,9 +2,10 @@
 
 import math
 
-import torch
-import torch.nn.functional as F
 import pytest
+torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")
+import torch.nn.functional as F
 
 from einops import rearrange, repeat
 

--- a/tests/ops/triton/test_ssd.py
+++ b/tests/ops/triton/test_ssd.py
@@ -1,9 +1,9 @@
 import math
 
-import torch
-import torch.nn.functional as F
-
 import pytest
+torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")
+import torch.nn.functional as F
 
 from einops import rearrange, repeat
 

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,11 +1,11 @@
-import torch
+import pytest
+torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")
 import torch.nn.functional as F
 
 from mamba_ssm.models.mixer_seq_simple import MambaLMHeadModel
 from mamba_ssm.models.config_mamba import MambaConfig
 from mamba_ssm.utils.generation import InferenceParams
-
-import pytest
 
 from einops import rearrange, repeat
 


### PR DESCRIPTION
## VRAM impact analysis
No change to runtime memory usage; only test imports updated.

## CPU validation results
- `pytest` -> `6 skipped`
- `pytest tests/test_model_cpu.py tests/training/test_trainer_cpu.py` -> no tests, file missing.
- `python benchmarks/vram_simulator.py --model base` -> file not found.
- `python -m mamba_ssm.utils.param_counter --config base` -> fails due to missing `torch`.

## Affected components diagram
```
 tests/
 ├── test_generation.py
 └── ops/
     ├── test_selective_scan.py
     ├── test_selective_scan_cpu.py
     └── triton/
         ├── test_layernorm_gated.py
         ├── test_selective_state_update.py
         └── test_ssd.py
```

## Risk assessment for OOM scenarios
None. These changes only modify test imports, so runtime memory usage is unaffected.

------
https://chatgpt.com/codex/tasks/task_e_6840a6d3e878832db00653c56b8d6cbc