### PR TITLE
[OPS] Add gradcheck test for selective_scan

### DIFF
--- a/tests/ops/test_selective_scan_gradcheck.py
+++ b/tests/ops/test_selective_scan_gradcheck.py
@@ -1,0 +1,29 @@
+import pytest
+
+# Skip if torch not available
+torch = pytest.importorskip("torch")
+
+# Skip if CUDA unavailable
+pytest.skip("CUDA required for gradcheck", allow_module_level=True) if not torch.cuda.is_available() else None
+
+from mamba_ssm.ops.selective_scan_interface import selective_scan_fn
+
+
+def _run_gradcheck():
+    device = 'cuda'
+    dtype = torch.double
+    batch, dim, seqlen, dstate = 1, 2, 4, 3
+    u = torch.randn(batch, dim, seqlen, dtype=dtype, device=device, requires_grad=True)
+    delta = torch.randn(batch, dim, seqlen, dtype=dtype, device=device, requires_grad=True)
+    A = torch.randn(dim, dstate, dtype=dtype, device=device, requires_grad=True)
+    B = torch.randn(dim, dstate, dtype=dtype, device=device, requires_grad=True)
+    C = torch.randn(dim, dstate, dtype=dtype, device=device, requires_grad=True)
+
+    def func(u, delta, A, B, C):
+        return selective_scan_fn(u, delta, A, B, C, delta_softplus=True)
+
+    return torch.autograd.gradcheck(func, (u, delta, A, B, C))
+
+
+def test_selective_scan_gradcheck():
+    assert _run_gradcheck()


### PR DESCRIPTION
## VRAM impact analysis
No effect on VRAM usage because the change only introduces a lightweight unit test.

## CPU validation results
Core tests fail to run due to missing files/torch installation but required commands were executed. The new gradcheck test is skipped when torch or CUDA is unavailable.

## Affected components diagram
```
tests/ops/test_selective_scan_gradcheck.py  --> new gradient check test
```

## Risk assessment for OOM scenarios
No additional risk. The test is tiny and guarded by a CUDA availability check, so it won't allocate GPU memory in unsupported environments.

------
https://chatgpt.com/codex/tasks/task_e_6840ad52efe8832dbc9405c94baba085