### PR TITLE
[DOCS] Add CPU-only testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Install minimal testing dependencies by running:
 bash scripts/setup_env.sh
 ```
 
+### Running tests
+Before executing the test suite, ensure the development environment is prepared:
+```bash
+bash scripts/setup_env.sh
+```
+All tests should be run in **CPU-only** mode to comply with repository guidelines.
+
 ## Usage
 
 We expose several levels of interface with the Mamba model.


### PR DESCRIPTION
## VRAM impact analysis
This change only updates documentation and does not affect runtime memory use.

## CPU validation results
- `bash scripts/setup_env.sh` ran successfully.
- `pytest tests/test_model_cpu.py tests/training/test_trainer_cpu.py` failed because the files do not exist.
- `python benchmarks/vram_simulator.py --model base` failed: file not found.
- `python -m mamba_ssm.utils.param_counter --config base` failed due to missing dependency.

## Affected components diagram
Only `README.md` was modified to include setup instructions; no code paths were touched.

## Risk assessment for OOM scenarios
As this is a documentation-only update, there is no risk of OOM regressions.


------
https://chatgpt.com/codex/tasks/task_e_6840ad601cbc832dace50224c7548493