### PR TITLE
[TRAIN] Update preset configs

### DIFF
--- a/mamba_ssm/training/autoconfig.py
+++ b/mamba_ssm/training/autoconfig.py
@@ -2,10 +2,12 @@ import torch
 from dataclasses import dataclass
 from typing import Dict
 
+# Preset configurations used to quickly instantiate common model sizes.
+# These values are referenced by the training scripts and some utilities.
 PRESET_CONFIGS: Dict[str, Dict[str, int]] = {
-    "tiny": {"d_model": 256, "n_layer": 12},
-    "small": {"d_model": 512, "n_layer": 16},
-    "base": {"d_model": 768, "n_layer": 24},
+    "tiny": {"d_model": 256, "n_layer": 8},
+    "small": {"d_model": 512, "n_layer": 10},
+    "base": {"d_model": 768, "n_layer": 12},
 }
 
 def detect_total_vram_gb(device=None) -> float:


### PR DESCRIPTION
## Summary
- adjust `PRESET_CONFIGS` defaults in `autoconfig.py`

## VRAM impact analysis
The preset changes reduce the default number of layers for each model size, lowering memory requirements when using `--preset` or `--auto-config`.

## CPU validation results
```
bash scripts/setup_env.sh
pytest tests/test_model_cpu.py tests/training/test_trainer_cpu.py
python benchmarks/vram_simulator.py --model base
python -m mamba_ssm.utils.param_counter --config base
```
All commands were attempted. Test collection failed because the project dependencies are missing and benchmark scripts were not found.

## Affected components diagram
```
mamba_ssm/
└── training/
    └── autoconfig.py  <-- updated preset configs
```

## Risk assessment for OOM scenarios
Lower default layer counts reduce per-sample VRAM usage, mitigating out-of-memory risks for users relying on automatic configuration.

------
https://chatgpt.com/codex/tasks/task_e_6840ad37fdd4832dadced46a31d8f2b1