### PR TITLE
[TEST] Add reset behavior test

### DIFF
--- a/tests/test_cache_consistency.py
+++ b/tests/test_cache_consistency.py
@@ -1,5 +1,6 @@
 """Tests ensuring caching yields identical results to full generation."""
 
+import pytest
 import torch
 from mamba_ssm.models.mixer_seq_simple import MambaLMHeadModel
 from mamba_ssm.models.config_mamba import MambaConfig
@@ -25,3 +26,27 @@ def test_cache_consistency():
         logits_cached.append(logits)
     logits_cached = torch.cat(logits_cached, dim=1)
     assert torch.allclose(logits_full, logits_cached, atol=1e-4, rtol=1e-4)
+
+
+def test_cache_reset_continues_generation():
+    """Ensure ``InferenceParams.reset`` clears state for extended generation."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    cfg = MambaConfig(d_model=64, n_layer=2, vocab_size=100)
+    model = MambaLMHeadModel(cfg, device=device)
+
+    # Use a small cache window then exceed it
+    inference_params = InferenceParams(max_seqlen=3, max_batch_size=1)
+    tokens = torch.randint(0, cfg.vocab_size, (1, 5), device=device)
+
+    for i in range(inference_params.max_seqlen):
+        model(tokens[:, i : i + 1], inference_params=inference_params, num_last_tokens=1)
+
+    with pytest.raises(AssertionError):
+        model(tokens[:, inference_params.max_seqlen : inference_params.max_seqlen + 1],
+              inference_params=inference_params,
+              num_last_tokens=1)
+
+    # Reset with a larger window and run the full sequence again
+    inference_params.reset(max_seqlen=tokens.shape[1], max_batch_size=1)
+    for i in range(tokens.shape[1]):
+        model(tokens[:, i : i + 1], inference_params=inference_params, num_last_tokens=1)


### PR DESCRIPTION
## VRAM impact analysis
- No model changes, only new test added.

## CPU validation results
- `pytest tests/test_model_cpu.py tests/training/test_trainer_cpu.py` (failed: file not found)
- `python benchmarks/vram_simulator.py --model base` (failed: script missing)
- `python -m mamba_ssm.utils.param_counter --config base` (failed: missing dependencies)
- `pytest tests/test_cache_consistency.py -k cache_reset_continues_generation -vv` (fails due to missing CUDA / Triton)

## Affected components diagram
- `tests/test_cache_consistency.py`

## Risk assessment for OOM scenarios
- Test runs on small tensors; minimal VRAM impact.

------
https://chatgpt.com/codex/tasks/task_e_6840ad57f3d0832d9493452fc6b904a9