### PR TITLE
[UTILS] fix batchwise min_p filtering and add test

### DIFF
--- a/mamba_ssm/utils/generation.py
+++ b/mamba_ssm/utils/generation.py
@@ -116,9 +116,10 @@ def sample(logits, top_k=1, top_p=0.0, min_p=0.0, temperature=1.0):
         else:
             if min_p > 0.0:
                 logits_top = logits.clone()
-                max_prob = logits_top[..., 0].item()
+                max_prob = logits_top.max(dim=-1).values
                 min_prob = max_prob * min_p
-                modify_logits_for_min_p_filtering(logits_top, min_prob)
+                for i in range(logits_top.size(0)):
+                    modify_logits_for_min_p_filtering(logits_top[i], min_prob[i].item())
                 if temperature != 1.0:
                     logits_top /= temperature
                 return torch.multinomial(

--- a/tests/test_sample_min_p.py
+++ b/tests/test_sample_min_p.py
@@ -1,0 +1,12 @@
+import torch
+from mamba_ssm.utils.generation import sample
+
+
+def test_min_p_filtering_per_batch():
+    torch.manual_seed(0)
+    logits = torch.tensor([[1.0, 2.0, 3.0], [1.0, 10.0, 0.0]])
+    out = sample(logits, top_k=0, top_p=0.0, min_p=0.5, temperature=1.0)
+    # First batch should never select index 0 as its logit is below the threshold
+    assert out[0].item() in {1, 2}
+    # Second batch should only be able to select the highest logit token
+    assert out[1].item() == 1


### PR DESCRIPTION
## VRAM impact analysis
The fix only updates CPU-side sampling logic and adds a small unit test. It does not change model architecture or tensor allocations, so VRAM usage is unaffected.

## CPU validation results
- `pytest tests/test_sample_min_p.py` passed.
- Attempts to run `pytest tests/test_model_cpu.py tests/training/test_trainer_cpu.py` failed because those files are missing.
- `python -m mamba_ssm.utils.param_counter --config base` executed and printed the parameter count.
- Benchmark scripts referenced in AGENTS guidelines were not present, so corresponding commands failed.

## Affected components diagram
```
mamba_ssm/utils/generation.py  <-- updated min_p filtering
tests/test_sample_min_p.py     <-- new unit test
```

## Risk assessment for OOM scenarios
Changes only affect logits filtering during sampling and operate on existing tensors. No additional memory is allocated per token, so risk of OOM remains unchanged.

------
https://chatgpt.com/codex/tasks/task_e_6840ad40fe84832db181f3d306457da2